### PR TITLE
fix:  object destruct exception

### DIFF
--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -320,7 +320,7 @@ export default {
             }
           } else if (typeof staticParts === 'object' && id.type === 'ObjectPattern') {
             // destructured object return where some properties are static
-            const property = id.properties.find(p => p.key === resolved.identifiers[0])
+            const property = id.properties.find(p => p.key?.name && p.key.name === resolved.identifiers[0]?.name)
             if (property) {
               return staticParts[property.key.name]
             }


### PR DESCRIPTION
Fix: while parsing object destruction, `id.properties` is an array of `AST.Property`, but `resolved.identifiers` is an array of 'AST.Identifier'